### PR TITLE
Package Dependencies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ flake8 = "==3.8.4"
 [packages]
 requests = "*"
 streamlit = "*"
+pandas = "==1.0.0"
 
 [requires]
 python_version = "3.7"


### PR DESCRIPTION
# Description
The latest streamlit package relies on pandas’ styler protected members. 

Calling style.apply triggers the pandas styler to be created.
https://github.com/Cazoo-uk/dbt-streamlit/blob/20fb82e6ce3472570069f7406e2a858d8da08c3c/src/pages/dbt_dashboard.py#L83

The streamlit package appears to break [here](https://github.com/streamlit/streamlit/blob/d525ee8040562bbfeaddaef9bc102f2420252f89/lib/streamlit/elements/legacy_data_frame.py#L169) due to relying on these protected members that have since changed.

https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/legacy_data_frame.py#L164-L165

Pinning pandas package to `1.0.0` seemed to install the styler protected members that conform to this streamlit version.

